### PR TITLE
Faster calculation of J in share verification.

### DIFF
--- a/lib/jobManager.js
+++ b/lib/jobManager.js
@@ -55,8 +55,8 @@ const ExtraNonceCounter = function (configInstanceId, extraNonce1Size) {
 
 function genIndexes(seed, height) {
     const hash = blake2b(seed);
-    const extendedHash = new Uint8Array(hash.length * 2);
-    extendedHash.__proto__ = hash.__proto__;
+    const extendedHash = Buffer.alloc(hash.length * 2);
+    // extendedHash.__proto__ = hash.__proto__;
     extendedHash.set(hash);
     extendedHash.set(hash, hash.length);
     return Array.from({length: 32}).map((_, index) => extendedHash.readUIntBE(index, 4) % parseInt(N(height)))
@@ -165,6 +165,13 @@ const JobManager = module.exports = function JobManager(options) {
     };
 
     this.processShare = function (jobId, previousDifficulty, difficulty, extraNonce1, extraNonce2, nTime, nonce, ipAddress, port, workerName) {
+        
+        console.log({
+            jobId,
+            extraNonce2: [extraNonce2, extraNonce2.length],
+            nonce: [nonce, nonce.length]
+        })
+
         const shareError = function (error) {
             _this.emit('share', {
                 job: jobId,
@@ -175,9 +182,8 @@ const JobManager = module.exports = function JobManager(options) {
             });
             return {error: error, result: null};
         };
-
         if (extraNonce2.length / 2 !== _this.extraNonce2Size)
-            return shareError([20, 'incorrect size of extra nonce2']);
+            return shareError([20, `incorrect size of extra nonce2 ${extraNonce2.length} vs ${_this.extraNonce2Size}`]);
 
         const job = this.validJobs[jobId];
 
@@ -200,6 +206,7 @@ const JobManager = module.exports = function JobManager(options) {
 
         const coinbaseBuffer = job.serializeCoinbase(extraNonce1Buffer, extraNonce2Buffer);
         const h = BigIntBuffer.toBufferBE(BigInt(job.rpcData.height), 4);
+
         const i = BigIntBuffer.toBufferBE(BigIntBuffer.toBigIntBE(blake2b(coinbaseBuffer).slice(24, 32)) % N(h), 4);
         const e = blake2b(Buffer.concat([
             i,
@@ -212,15 +219,19 @@ const JobManager = module.exports = function JobManager(options) {
                 Buffer.concat([item, h, M])
             ).slice(1, 32)
         )).reduce((a, b) => a + b);
-
+        console.log("f", f)
         const fh = BigIntBuffer.toBigIntBE(blake2b(BigIntBuffer.toBufferBE(f, 32)));
+        console.log("calculated FH", fh)
         let blockHash = "";
+        
         //Check if share is a block candidate (matched network difficulty)
         if (job.rpcData.b.gte(fh)) {
             // must submit solution
             blockHash = BigIntBuffer.toBufferBE(f, 32)
         } else {
             //Check if share didn't reached the miner's difficulty)
+
+            //console.log((new BigNumber(job.jobParams[6])).multipliedBy(difficulty).toString(), (fh))
             if ((new BigNumber(job.jobParams[6])).multipliedBy(difficulty).lte(fh)) {
                 return shareError([23, 'Low Difficulty share']);
             }

--- a/lib/jobManager.js
+++ b/lib/jobManager.js
@@ -55,8 +55,11 @@ const ExtraNonceCounter = function (configInstanceId, extraNonce1Size) {
 
 function genIndexes(seed, height) {
     const hash = blake2b(seed);
-    const extendedHash = new Uint8Array(hash.length * 2);
-    extendedHash.__proto__ = hash.__proto__;
+    // Buffer alloc is faster then using the UInt8Array and changing out protos.
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto
+    const extendedHash = Buffer.alloc(hash.length * 2);
+//     const extendedHash = new Uint8Array(hash.length * 2);
+//     extendedHash.__proto__ = hash.__proto__;
     extendedHash.set(hash);
     extendedHash.set(hash, hash.length);
     return Array.from({length: 32}).map((_, index) => extendedHash.readUIntBE(index, 4) % parseInt(N(height)))

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -508,7 +508,7 @@ var pool = module.exports = function pool(options, authorizeFn){
                     client.socket.localPort,
                     params.name
                 );
-
+                        
                 resultCallback(result.error, result.result ? true : null);
 
             }).on('malformedMessage', function (message) {

--- a/lib/stratum.js
+++ b/lib/stratum.js
@@ -101,6 +101,7 @@ var StratumClient = function(options){
                     return;
                 }
                 _this.extraNonce1 = extraNonce1;
+
                 sendJson({
                     id: message.id,
                     result: [
@@ -157,6 +158,8 @@ var StratumClient = function(options){
             considerBan(false);
             return;
         }
+        
+
         _this.emit('submit',
             {
                 name        : message.params[0],
@@ -277,7 +280,7 @@ var StratumClient = function(options){
     };
 
     this.sendMiningJob = function(jobParams){
-
+        console.log("SENDING MINING JOB")
         var lastActivityAgo = Date.now() - _this.lastActivity;
         if (lastActivityAgo > options.connectionTimeout * 1000){
             _this.emit('socketTimeout', 'last submitted a share was ' + (lastActivityAgo / 1000 | 0) + ' seconds ago');
@@ -293,6 +296,7 @@ var StratumClient = function(options){
             }
         }
         var params = [...jobParams]
+        console.log(params)
         if(typeof params[6] !== 'string') {
             if (options.multiplyDifficulty) {
                 var b = params[6].multipliedBy(this.difficulty);

--- a/start.js
+++ b/start.js
@@ -20,7 +20,7 @@ var pool = Stratum.createPool({
     "coin": myCoin,
     "extraNonce1Size": 1,
 
-    "address": "9fs2EgK8MD8ALEEjsE9oVFjexZdYFQoQWxBTPnxCdsU6ubxVLqX", //Address to where block rewards are given
+    "address": "9iLrHXnsEMjN3r6CFAWRAquPB9BRbSys33zvZ79CEkDZYjaTzFm", //Address to where block rewards are given
 
     /* Block rewards go to the configured pool wallet address to later be paid out to miners,
        except for a percentage that can go to, for examples, pool operator(s) as pool fees or
@@ -86,15 +86,15 @@ var pool = Stratum.createPool({
             /* Variable difficulty is a feature that will automatically adjust difficulty for
                individual miners based on their hashrate in order to lower networking overhead */
             "varDiff": {
-                "minDiff": 8, //Minimum difficulty
-                "maxDiff": 16431986528747520, //Network difficulty will be used if it is lower than this
+                "minDiff": 164319, //Minimum difficulty
+                "maxDiff": 1643198652874752, //Network difficulty will be used if it is lower than this
                 "targetTime": 15, //Try to get 1 share per this many seconds
                 "retargetTime": 10, //Check to see if we should retarget every this many seconds
                 "variancePercent": 30 //Allow time to very this % from target without retargeting
             }
         },
         "3256": { //Another port for your miners to connect to, this port does not use varDiff
-            "diff": 256 //The pool difficulty
+            "diff": 12800000 //The pool difficulty
         }
     },
 
@@ -107,7 +107,7 @@ var pool = Stratum.createPool({
           - https://en.bitcoin.it/wiki/Running_bitcoind */
     "daemons": [
         {   //Main daemon instance
-            "host": "213.239.193.208",
+            "host": "143.198.188.87",
             "port": 9053,
             "user": "litecoinrpc",
             "password": "testnet"


### PR DESCRIPTION
I saw we are changing protos, and know that it is very slow and not reccomended...
I figure we want share verification to be fast so I used Buffer.alloc so they do not need to change out the `__proto__` for a uint8array.